### PR TITLE
Update Dependencies & Migrate to NET 6.0

### DIFF
--- a/XCIRepacker/Program.cs
+++ b/XCIRepacker/Program.cs
@@ -2,8 +2,15 @@
 using LibHac.Fs;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
+using LibHac.Common.Keys;
+using LibHac.Fs.Fsa;
+using LibHac.FsSystem;
+using LibHac.Tools.Fs;
+using LibHac.Tools.FsSystem;
+using Path = System.IO.Path;
 
 namespace XCIRepacker
 {
@@ -27,7 +34,7 @@ namespace XCIRepacker
 
             if (args.Length == 1)
             {
-                Keyset keySet = OpenKeyset();
+                KeySet keySet = OpenKeySet();
 
                 if (keySet != null)
                 {
@@ -40,10 +47,10 @@ namespace XCIRepacker
                             if (xciFile.HasPartition(XciPartitionType.Secure))
                             {
                                 XciPartition xciPartition = xciFile.OpenPartition(XciPartitionType.Root);
-
-                                IFile ncaStorage = xciPartition.OpenFile("secure", OpenMode.Read);
-
-                                string outputPath = Path.GetDirectoryName(args[0]) + Path.GetFileNameWithoutExtension(args[0]) + ".nsp";
+                                
+                                IFile ncaStorage = xciPartition.OpenFile(xciPartition.Files.FirstOrDefault(x=>x.Name == "secure"), OpenMode.Read);
+                                
+                                var outputPath = Path.Combine(Path.GetDirectoryName(args[0]), $"{Path.GetFileNameWithoutExtension(args[0])}.nsp");
 
                                 Console.WriteLine($" Input  File Path: {args[0]}");
                                 Console.WriteLine($" Output File Path: {outputPath}" + Environment.NewLine);
@@ -165,11 +172,11 @@ namespace XCIRepacker
             {
                 Console.WriteLine(" USAGE: XCIRepacker.exe \"PathOfFile.xci\"");
             }
-
+            Console.WriteLine("Press any key to exit...");
             Console.ReadKey();
         }
 
-        public static Keyset OpenKeyset()
+        public static KeySet OpenKeySet()
         {
             string keyFileName  = "prod.keys";
             string homeKeyFile  = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".switch", keyFileName);
@@ -177,12 +184,12 @@ namespace XCIRepacker
 
             if (File.Exists(localKeyFile))
             {
-                return ExternalKeys.ReadKeyFile(localKeyFile);
+                return ExternalKeyReader.ReadKeyFile(localKeyFile);
             }
 
             if (File.Exists(homeKeyFile))
             {
-                return ExternalKeys.ReadKeyFile(homeKeyFile);
+                return ExternalKeyReader.ReadKeyFile(homeKeyFile);
             }
 
             return null;

--- a/XCIRepacker/XCIRepacker.csproj
+++ b/XCIRepacker/XCIRepacker.csproj
@@ -1,73 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9D5F0082-18FA-4599-A510-B9186432170C}</ProjectGuid>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RootNamespace>XCIRepacker</RootNamespace>
-    <AssemblyName>XCIRepacker</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibHac, Version=0.5.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibHac.0.5.1\lib\net46\LibHac.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Core" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="LibHac" Version="0.16.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/XCIRepacker/packages.config
+++ b/XCIRepacker/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="LibHac" version="0.5.1" targetFramework="net461" />
-  <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net461" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
## Summary

This PR upgrades the dependency for libHac to the latest version and migrates the project from NETFX to NET 6.0. This PR also fixes a glaring issue with the path logic used for determining the file output.